### PR TITLE
Fix #24 Quickfix by inspecting for potentially empty objects

### DIFF
--- a/TagLab.py
+++ b/TagLab.py
@@ -2202,7 +2202,9 @@ class TagLab(QMainWindow):
     @pyqtSlot()
     def noteChanged(self):
 
-        if len(self.activeviewer.selected_blobs) > 0:
+        if (self.activeviewer is None):
+            return
+        elif len(self.activeviewer.selected_blobs) > 0:
             for blob in self.activeviewer.selected_blobs:
                 blob.note = self.editNote.toPlainText()
 


### PR DESCRIPTION
Right Click -> Select All in the Note edit box was triggering an error as it was notifying about a change on a non-existing object.
A quickfix is to inspect `activeviewer` object in `noteChanged(self)` before querying for number of selected objects. If the object is empty (None) the just return