### PR TITLE
explicit casts to int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,7 @@
 
-models/deeplab-resnet.pth.tar
-models/DEEPLAB_lr=5e-05_L2=0.0005_100_moorea_rescaled_pocillopora_dead.net
-models/DEEPLAB_lr=5e-05_L2=0.0005_60_moorea_rescaled_pocillopora.net
+models/*.pth.tar
+models/*.net
 models/*.pth
-models/Pocillopora.net
-models/Porites.net
-models/Pocillopora_Porite_Montipora3.net
-models/Pocillopora_Porite_Montipora.net
-models/DEEPLAB_lr=5e-05_L2=0.0005_100_rescaled_6classes.net
-models/DEEPLAB_lr=5e-05_L2=0.0005_100_rescaled_4classes.net
 coraline/src/getopt.h
 coraline/libcoraline.dylib
 
@@ -165,4 +158,3 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-

--- a/source/QtImageViewerPlus.py
+++ b/source/QtImageViewerPlus.py
@@ -324,8 +324,8 @@ class QtImageViewerPlus(QtImageViewer):
 
         w = self.viewport().width()
         h = self.viewport().height()
-        posx = w * 0.8
-        posy = h * 0.9
+        posx = int(w * 0.8)
+        posy = int(h * 0.9)
 
         self.scene_overlay.setSceneRect(0,0,w,h)
 
@@ -889,7 +889,7 @@ class QtImageViewerPlus(QtImageViewer):
         n = int(math.log10(length))
         cute_length = round(length / math.pow(10,n)) * math.pow(10,n)
 
-        length_in_pixel = (cute_length * zoom_factor) / self.px_to_mm
+        length_in_pixel = int((cute_length * zoom_factor) / self.px_to_mm)
 
         if cute_length < 100.0:
             txt = "{:.1f} mm".format(cute_length)
@@ -899,8 +899,8 @@ class QtImageViewerPlus(QtImageViewer):
             txt = "{:.1f} m".format(cute_length / 1000.0)
 
 
-        posx = w - length_in_pixel - 20
-        posy = h * 0.95
+        posx = int(w - length_in_pixel - 20)
+        posy = int(h * 0.95)
 
         self.scene_overlay.setSceneRect(0,0,w,h)
 

--- a/source/tools/Scribbles.py
+++ b/source/tools/Scribbles.py
@@ -42,7 +42,7 @@ class Scribbles(QObject):
 
     def setCustomCursor(self):
 
-        cursor_size = self.current_size * self.scale_factor
+        cursor_size = int(self.current_size * self.scale_factor)
 
         pxmap = QPixmap(cursor_size, cursor_size)
         pxmap.fill(QColor("transparent"))


### PR DESCRIPTION
some variables need to be casted explicitly to int, in order to avoid runtime errors on linux