### PR TITLE
DefaultDictionary: fix for 'Name' issue, and lost/modified default_dictionary

### DIFF
--- a/source/Project.py
+++ b/source/Project.py
@@ -324,7 +324,8 @@ class Project(QObject):
                 description = label['description']
                 self.labels[name] = Label(id=id, name=name, fill=fill, border=border)
 
-        except:
+        except Exception as e:
+            QMessageBox.critical(None, "Error", f"Error loading dictionary: {filename}\n{e}")
             return False
 
         return True

--- a/source/QtSettingsWidget.py
+++ b/source/QtSettingsWidget.py
@@ -40,7 +40,8 @@ class generalSettingsWidget(QWidget):
 
         self.checkbox_autosave = QCheckBox("Autosave")
         self.spinbox_autosave_interval = QSpinBox()
-        self.spinbox_autosave_interval.setRange(5, 15)
+        self.spinbox_autosave_interval.setRange(1, 15)
+        self.spinbox_autosave_interval.setValue(5)
         self.lbl_autosave_1 = QLabel("Every ")
         self.lbl_autosave_2 = QLabel(" minutes.")
 
@@ -52,7 +53,7 @@ class generalSettingsWidget(QWidget):
         self.combo_research_field.setCurrentIndex(0)
 
         self.lbl_default_dict = QLabel("Default dictionary: ")
-        self.edit_default_dict = QLineEdit("dictionaries/scripps.json")
+        self.edit_default_dict = QLineEdit(self.settings.value("default-dictionary"))
         self.btn_default_dict = QPushButton("...")
         self.btn_default_dict.setFixedWidth(20)
         self.btn_default_dict.clicked.connect(self.chooseDict)
@@ -90,7 +91,7 @@ class generalSettingsWidget(QWidget):
 
         filters = "JSON (*.json)"
         file_name, _ = QFileDialog.getOpenFileName(self, "Default Dictionary File", "", filters)
-        if file_name:
+        if file_name and os.path.exists(file_name):
             default_dict = os.path.relpath(file_name, start=self.taglab_dir)
             self.edit_default_dict.setText(default_dict)
             self.settings.setValue("default-dictionary", default_dict)
@@ -420,6 +421,12 @@ class QtSettingsWidget(QWidget):
 
         self.settings = QSettings("VCLAB", "TagLab")
 
+        default_dict = "dictionaries/scripps.json"
+        # Check that the default dictionary isn't None, if it is set it to the default one
+        # Otherwise, don't set a default dictionary in registry
+        if not "default-dictionary" in self.settings.allKeys() and os.path.exists(default_dict):
+            self.settings.setValue("default-dictionary", default_dict)
+
         self.setStyleSheet("background-color: rgb(40,40,40); color: white")
         self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self.setMinimumWidth(300)
@@ -498,7 +505,3 @@ class QtSettingsWidget(QWidget):
     @pyqtSlot(int)
     def display(self, i):
         self.stackedwidget.setCurrentIndex(i)
-
-
-
-


### PR DESCRIPTION
Loading a default_dict that doesn't exist on a computer (i.e., it was moved, deleted, renamed) causes TagLab to brick because the path stored in the registry points to the old default_dict, which never gets updated. TagLab will try to open the path that is stored in the registry, but it doesn't exist and never opens causing a crash.

Fix is to check that the path / value stored in the registry actually exists before trying to load (in the case that it was moved, deleted, renamed), and if it does exist, loads. If it doesn't, then it falls back on default_dict `dictionaries/scripps.json`, checks if it exists, then loads. If it doesn't exist, spits out an error message box an alerts the user, but still loads TagLab with an empty dict, allowing the user to actually update the old default_dict.