### PR TITLE
RITM & 4-Clicks: try/except blocks when resetting networks

### DIFF
--- a/source/tools/FourClicks.py
+++ b/source/tools/FourClicks.py
@@ -208,12 +208,14 @@ class FourClicks(Tool):
                 self.device = device
 
     def resetNetwork(self):
-        torch.cuda.empty_cache()
-        if self.deepextreme_net is not None:
-            del self.deepextreme_net
-            self.deepextreme_net = None
+        try:
+            torch.cuda.empty_cache()
+            if self.deepextreme_net is not None:
+                del self.deepextreme_net
+                self.deepextreme_net = None
+        except:
+            pass
 
     def reset(self):
         self.resetNetwork()
         self.pick_points.reset()
-

--- a/source/tools/Ritm.py
+++ b/source/tools/Ritm.py
@@ -329,11 +329,13 @@ class Ritm(Tool):
         return True
 
     def resetNetwork(self):
-
-        torch.cuda.empty_cache()
-        if self.ritm_net is not None:
-            del self.ritm_net
-            self.ritm_net = None
+        try:
+            torch.cuda.empty_cache()
+            if self.ritm_net is not None:
+                del self.ritm_net
+                self.ritm_net = None
+        except:
+            pass
 
     def apply(self):
         """
@@ -417,5 +419,3 @@ class Ritm(Tool):
             brush = self.viewerplus.project.classBrushFromName(self.blob_to_correct)
 
         utils.drawBlob(blob, brush, scene, self.viewerplus.transparency_value, redraw=False)
-
-


### PR DESCRIPTION
For some reason, sometimes users have TagLab crash when using the RITM or 4-Clicks tools. The crash occurs when the method called to reset the network is invoked (probably due to an OOM). Not quite sure why it's happening, but does on occasion.

Simple fix until knowing more is adding try/except blocks around empty_cache call.

![image](https://github.com/user-attachments/assets/d4c4c6fc-1014-480d-8264-93f08e0fc5a1)
