### PR TITLE
Install: Remove SAM flag as optional, force install + Setting Sam.py device

### DIFF
--- a/install.py
+++ b/install.py
@@ -65,8 +65,6 @@ if len(sys.argv)>=2:
     # if sys.argv contains an argument 'cpu'
     if 'cpu' in sys.argv:
         flag_install_pytorch_cpu = True
-    if 'SAM' in sys.argv:
-        flag_install_SAM = True
 
 
 # checking supported compute platform (cuda, cpu or rocm)
@@ -236,6 +234,7 @@ install_requires = [
     'shapely',
     'pycocotools',
     'qhoptim',
+    'segment-anything',
 
     # CoralNet Toolbox
     'Requests',
@@ -246,9 +245,6 @@ install_requires = [
     #forcing numpy 1.24.2 version
     'numpy==1.24.4',
 ]
-
-if flag_install_SAM:
-    install_requires.append('segment-anything')
 
 # if on windows, first install the msvc runtime
 if osused == 'Windows':
@@ -318,10 +314,8 @@ from os import path
 import urllib.request
 this_directory = path.abspath(path.dirname(__file__))
 net_file_names = ['dextr_corals.pth', 'deeplab-resnet.pth.tar', 'ritm_corals.pth',
-                  'pocillopora.net', 'porites.net', 'pocillopora_porite_montipora.net']
-
-if flag_install_SAM:
-    net_file_names.append('sam_vit_h_4b8939.pth')
+                  'pocillopora.net', 'porites.net', 'pocillopora_porite_montipora.net',
+                  'sam_vit_h_4b8939.pth']
 
 for net_name in net_file_names:
     filename_dextr_corals = 'dextr_corals.pth'

--- a/source/tools/Sam.py
+++ b/source/tools/Sam.py
@@ -235,13 +235,13 @@ class Sam(Tool):
             models_dir = "models/"
             network_name = os.path.join(models_dir, sam_checkpoint)
 
-            # if not torch.cuda.is_available():
-            #     print("CUDA NOT AVAILABLE!")
-            #     device = torch.device("cpu")
-            # else:
-            #     device = torch.device("cuda:0")
+            if not torch.cuda.is_available():
+                print("CUDA NOT AVAILABLE!")
+                device = torch.device("cpu")
+            else:
+                device = torch.device("cuda:0")
 
-            self.device = "cuda"
+            self.device = device
             self.sam_net = sam_model_registry[model_type](checkpoint=network_name)
             self.sam_net.to(device=self.device)
 
@@ -413,5 +413,3 @@ class Sam(Tool):
                 self.viewerplus.scene.removeItem(self.rect_item)
             self.rect_item = None
             # self.center_item.setVisible(False)
-       
-       


### PR DESCRIPTION
Just a suggestion, but right now SAM is considered optional via flag, however, if not installed TagLab won't launch because there is an attempt to import segment_anything in the SAM scripts. An alternative is to wrap the imports in try / except blocks, but I'm not sure how that would affect other things down the line (for example, if someone clicks on the SAM tool)

Secondly, `self.device` was being set to `cuda` even if only on `cpu`, simple fix.

This let's me use SAM on CPU properly (both tools)