### PR TITLE
startup fix

### DIFF
--- a/TagLab.py
+++ b/TagLab.py
@@ -18,7 +18,6 @@
 #GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
 # for more details.
 
-import rasterio 
 import sys
 import os
 import datetime
@@ -30,6 +29,8 @@ import platform
 import pandas as pd
 import importlib
 
+# import PyQt before rasterio causes a crash
+import rasterio 
 from PyQt5.QtCore import Qt, QSize, QMargins, QDir, QPoint, QPointF, QRectF, QTimer, pyqtSlot, pyqtSignal, QSettings, QFileInfo, QModelIndex
 from PyQt5.QtGui import QFontDatabase, QFont, QPixmap, QIcon, QKeySequence, QPen, QImageReader, QImage
 from PyQt5.QtWidgets import QApplication, QWidget, QMainWindow, QFileDialog, QComboBox, QMenuBar, QMenu, QSizePolicy, QScrollArea, \

--- a/TagLab.py
+++ b/TagLab.py
@@ -37,27 +37,13 @@ from PyQt5.QtWidgets import QApplication, QWidget, QMainWindow, QFileDialog, QCo
     QMessageBox, QGroupBox, QLayout, QHBoxLayout, QVBoxLayout, QFrame, QDockWidget, QTextEdit, QAction, \
     QDialog
 
-from source.QtExportDXF import QtDXFExport  # Import the dxf export dialog
-from source.QtExportSVG import QtSVGExport  # Import the svg export dialog
-
-
-
 import pprint
 # PYTORCH
-from source.QtAlignmentToolWidget import QtAlignmentToolWidget
-
-try:
-    import torch
-    from torch.nn.functional import upsample
-except Exception as e:
-    print("Incompatible version between pytorch, cuda and python.\n" +
-          "Knowing working version combinations are\n: Cuda 10.0, pytorch 1.0.0, python 3.6.8" + str(e))
    # exit()
 
 # CUSTOM
 import csv
 import source.Mask as Mask
-import source.RasterOps as rasterops
 from source.QtImageViewerPlus import QtImageViewerPlus
 from source.QtMapViewer import QtMapViewer
 from source.QtSettingsWidget import QtSettingsWidget
@@ -70,32 +56,19 @@ from source.QtLayersWidget import QtLayersWidget
 from source.QtHelpWidget import QtHelpWidget
 
 from source.QtProgressBarCustom import QtProgressBarCustom
-from source.QtHistogramWidget import QtHistogramWidget
-from source.QtClassifierWidget import QtClassifierWidget
-from source.QtNewDatasetWidget import QtNewDatasetWidget
-from source.QtSampleWidget import QtSampleWidget
-from source.QtGeoreferencingWidget import QtGeoreferencingWidget
-from source.QtTrainingResultsWidget import QtTrainingResultsWidget
-from source.QtTYNWidget import QtTYNWidget
-from source.QtDatasetManagerWidget import QtDatasetManagerWidget
 from source.QtComparePanel import QtComparePanel
 from source.QtTablePanel import QtTablePanel
 from source.QtExportAnnAsTable import QtExportAnnAsTable
 from source.QtTableLabel import QtTableLabel
 from source.QtProjectWidget import QtProjectWidget
-from source.QtProjectEditor import QtProjectEditor
 from source.Project import Project, loadProject
 from source.Point import Point
 from source.Image import Image
-from source.MapClassifier import MapClassifier
-from source.NewDataset import NewDataset
 from source.QtGridWidget import QtGridWidget
 from source.QtDictionaryWidget import QtDictionaryWidget
 from source.QtRegionAttributesWidget import QtRegionAttributesWidget
 from source.QtShapefileAttributeWidget import QtAttributeWidget
 from source.QtGeometricInfoWidget import QtGeometricInfoWidget
-from source.QtCourseAnalysis import QtCourseAnalysis
-
 from source.QtSelection import QtSelectByPropertiesWidget
 
 import math
@@ -104,18 +77,13 @@ from source.QtPanelInfo import QtPanelInfo
 from source.Sampler import Sampler
 
 from source.QtImportViscoreWidget import QtImportViscoreWidget
-from source.QtCoralNetToolboxWidget import QtCoralNetToolboxWidget
 from source.QtExportCoralNetDataWidget import QtExportCoralNetDataWidget
 
 from source import genutils
 from source.Blob import Blob
 from source.Shape import Layer, Shape
 
-from source.Tools import Tools
-
 # training modules
-from models.coral_dataset import CoralsDataset
-import models.training as training
 
 
 # LOGGING
@@ -3358,6 +3326,8 @@ class TagLab(QMainWindow):
             msgBox.exec()
             return
 
+        from source.QtCourseAnalysis import QtCourseAnalysis
+
         rowAnalysis_widget = QtCourseAnalysis(view, parent = self)
         rowAnalysis_widget.setWindowModality(Qt.NonModal)
         rowAnalysis_widget.show()
@@ -3870,6 +3840,8 @@ class TagLab(QMainWindow):
         if self.activeviewer is not None:
             if self.activeviewer.image is not None:
                 if self.georeferencing_tool_widget is None:
+                    from source.QtGeoreferencingWidget import QtGeoreferencingWidget
+
                     self.disableSplitScreen()
                     self.georeferencing_tool_widget = QtGeoreferencingWidget(self.project, parent=self)
                     self.georeferencing_tool_widget.setWindowModality(Qt.NonModal)
@@ -3909,6 +3881,8 @@ class TagLab(QMainWindow):
         """
         Assign georeferencing information to the current map.
         """
+
+        import source.RasterOps as rasterops
 
         active_image = self.activeviewer.image
         qimg = self.activeviewer.channel.qimage
@@ -4003,6 +3977,8 @@ class TagLab(QMainWindow):
         if self.activeviewer is not None:
             if self.activeviewer.image is not None:
                 if self.sample_point_widget is None:
+                    from source.QtSampleWidget import QtSampleWidget
+
                     self.disableSplitScreen()
                     self.sample_point_widget = QtSampleWidget(active_image=self.activeviewer.image,
                                                               working_area=self.project.working_area,
@@ -4133,6 +4109,8 @@ class TagLab(QMainWindow):
     @pyqtSlot()
     def openProjectEditor(self):
         if self.projectEditor is None:
+            from source.QtProjectEditor import QtProjectEditor
+
             self.projectEditor = QtProjectEditor(self.project, parent=self)
 
         self.projectEditor.fillMaps()
@@ -4157,6 +4135,8 @@ class TagLab(QMainWindow):
             return
 
         if self.align_tool_widget is None:
+            from source.QtAlignmentToolWidget import QtAlignmentToolWidget
+
             self.align_tool_widget = QtAlignmentToolWidget(self.taglab_dir, self.project, parent=self)
             self.align_tool_widget.setWindowModality(Qt.WindowModal)
             self.align_tool_widget.closed.connect(self.closeAlignmentTool)
@@ -4905,6 +4885,8 @@ class TagLab(QMainWindow):
         if not self.shapefile_filename:
             QApplication.restoreOverrideCursor()
             return
+        import source.RasterOps as rasterops
+
         #read only attributes
         data = rasterops.read_attributes(self.shapefile_filename)
         QApplication.restoreOverrideCursor()
@@ -4916,6 +4898,8 @@ class TagLab(QMainWindow):
 
     @pyqtSlot(str,list,list)
     def readShapes(self, shapetype, attributelist, classes_list):
+
+        import source.RasterOps as rasterops
 
         gf = self.activeviewer.image.georef_filename
 
@@ -5150,6 +5134,7 @@ class TagLab(QMainWindow):
     def exportHistogramFromAnn(self):
 
         if self.activeviewer is not None:
+            from source.QtHistogramWidget import QtHistogramWidget
 
             histo_widget = QtHistogramWidget(self.activeviewer.annotations, self.project.labels,
                                              self.activeviewer.image.pixelSize(),
@@ -5174,6 +5159,8 @@ class TagLab(QMainWindow):
         output_filename, _ = QFileDialog.getSaveFileName(self, "Save Shapefile as", self.taglab_dir, filters)
 
         if output_filename:
+            import source.RasterOps as rasterops
+
             blobs = self.activeviewer.annotations.seg_blobs
             gf = self.activeviewer.image.georef_filename
             rasterops.write_shapefile(self.project, self.activeviewer.image, blobs, gf, output_filename)
@@ -5191,6 +5178,8 @@ class TagLab(QMainWindow):
             return
         if self.activeviewer.image is None:
             return
+        from source.QtExportDXF import QtDXFExport  # Import the dxf export dialog
+
         # Show the DXF export dialog
         optionsDialog = QtDXFExport(self)
         optionsDialog.setWindowModality(Qt.WindowModal)
@@ -5203,6 +5192,8 @@ class TagLab(QMainWindow):
             return
         if self.activeviewer.image is None:
             return
+        from source.QtExportSVG import QtSVGExport  # Import the svg export dialog
+
         # Show the SVG export dialog
         optionsDialog = QtSVGExport(self)
         optionsDialog.setWindowModality(Qt.WindowModal)
@@ -5231,6 +5222,8 @@ class TagLab(QMainWindow):
         output_filename, _ = QFileDialog.getSaveFileName(self, "Output GeoTiff", "", filters)
 
         if output_filename:
+
+            import source.RasterOps as rasterops
 
             QApplication.setOverrideCursor(Qt.WaitCursor)
 
@@ -5270,6 +5263,8 @@ class TagLab(QMainWindow):
         output_filename, _ = QFileDialog.getSaveFileName(self, "Output GeoTiff", "", filters)
 
         if output_filename:
+            import source.RasterOps as rasterops
+
             QApplication.setOverrideCursor(Qt.WaitCursor)
 
             myimage_np = genutils.qimageToNumpyArray(self.activeviewer.image.getRGBChannel().qimage)
@@ -5291,6 +5286,7 @@ class TagLab(QMainWindow):
         if self.activeviewer is not None:
             if self.activeviewer.image is not None:
                 if self.newDatasetWidget is None:
+                    from source.QtNewDatasetWidget import QtNewDatasetWidget
 
                     if not self.activeviewer.image.export_dataset_area:
                         self.activeviewer.image.export_dataset_area = [0, 0 , self.activeviewer.img_map.width(), self.activeviewer.img_map.height()]
@@ -5330,6 +5326,9 @@ class TagLab(QMainWindow):
                 msgBox.setText("Please, choose a folder to export the dataset.")
                 msgBox.exec()
                 return
+
+            from source.NewDataset import NewDataset
+            import models.training as training
 
             QApplication.setOverrideCursor(Qt.WaitCursor)
             self.setupProgressBar()
@@ -5420,6 +5419,9 @@ class TagLab(QMainWindow):
 
     @pyqtSlot()
     def trainNewNetwork(self):
+
+        import models.training as training
+        from source.QtTrainingResultsWidget import QtTrainingResultsWidget
 
         dataset_folder = self.trainYourNetworkWidget.getDatasetFolder()
 
@@ -5550,6 +5552,8 @@ class TagLab(QMainWindow):
     def trainYourNetwork(self):
 
         if self.trainYourNetworkWidget is None:
+            from source.QtTYNWidget import QtTYNWidget
+
             self.trainYourNetworkWidget = QtTYNWidget(self.project.labels, self.TAGLAB_VERSION, parent=self)
             self.trainYourNetworkWidget.setWindowModality(Qt.WindowModal)
             self.trainYourNetworkWidget.launchTraining.connect(self.trainNewNetwork)
@@ -5560,6 +5564,8 @@ class TagLab(QMainWindow):
     def openDatasetManager(self):
 
         if self.datasetManagerWidget is None:
+            from source.QtDatasetManagerWidget import QtDatasetManagerWidget
+
             self.datasetManagerWidget = QtDatasetManagerWidget(self.project.labels, self.TAGLAB_VERSION, parent=self)
             self.datasetManagerWidget.setWindowModality(Qt.WindowModal)
             # self.trainYourNetworkWidget.launchTraining.connect(self.trainNewNetwork)
@@ -5588,6 +5594,8 @@ class TagLab(QMainWindow):
         output_filename, _ = QFileDialog.getSaveFileName(self, "Save raster as", self.taglab_dir, filters)
 
         if output_filename:
+
+            import source.RasterOps as rasterops
 
             QApplication.setOverrideCursor(Qt.WaitCursor)
 
@@ -5726,6 +5734,8 @@ class TagLab(QMainWindow):
         Opens the CoralNetToolbox Widget in a new window.
         """
         try:
+            from source.QtCoralNetToolboxWidget import QtCoralNetToolboxWidget
+
             self.coralNetToolbox = QtCoralNetToolboxWidget(self)
             self.coralNetToolbox.show()
         except Exception as e:
@@ -5754,6 +5764,8 @@ class TagLab(QMainWindow):
 
         georef_filename = self.activeviewer.image.georef_filename
         blobs = self.activeviewer.annotations.seg_blobs
+        import source.RasterOps as rasterops
+
         rasterops.calculateAreaUsingSlope(input_tiff, blobs)
 
         QApplication.restoreOverrideCursor()
@@ -5855,6 +5867,8 @@ class TagLab(QMainWindow):
     #REFACTOR networks should be moved to a new class
     def resetNetworks(self):
 
+        import torch
+
         torch.cuda.empty_cache()
 
         if self.classifier is not None:
@@ -5882,6 +5896,8 @@ class TagLab(QMainWindow):
             self.btnAutoClassification.setChecked(True)
 
             if self.classifierWidget is None:
+                from source.QtClassifierWidget import QtClassifierWidget
+
                 self.classifierWidget = QtClassifierWidget(self.available_classifiers, parent=self)
                 self.classifierWidget.setAttribute(Qt.WA_DeleteOnClose)
                 self.classifierWidget.btnApply.clicked.connect(self.applyClassifier)
@@ -5958,6 +5974,8 @@ class TagLab(QMainWindow):
             self.resetNetworks()
             self.setupProgressBar()
             QApplication.processEvents()
+
+            from source.MapClassifier import MapClassifier
 
             self.classifier = MapClassifier(classifier_selected, self.project.labels)
             self.classifier.updateProgress.connect(self.progress_bar.setProgress)
@@ -6047,6 +6065,8 @@ class TagLab(QMainWindow):
 
             message = "[AUTOCLASS] Automatic classification STARTS.. (classifier: )" + classifier_selected['Classifier Name']
             logfile.info(message)
+
+            from source.MapClassifier import MapClassifier
 
             self.classifier = MapClassifier(classifier_selected, self.project.labels)
             self.classifier.updateProgress.connect(self.progress_bar.setProgress)

--- a/TagLab.py
+++ b/TagLab.py
@@ -39,8 +39,6 @@ from PyQt5.QtWidgets import QApplication, QWidget, QMainWindow, QFileDialog, QCo
     QDialog
 
 import pprint
-# PYTORCH
-   # exit()
 
 # CUSTOM
 import csv
@@ -5867,9 +5865,12 @@ class TagLab(QMainWindow):
 
     #REFACTOR networks should be moved to a new class
     def resetNetworks(self):
-
-        import torch
-
+        try:
+            import torch
+        except Exception as e:
+            print("Incompatible version between pytorch, cuda and python.\n" +
+                "Knowing working version combinations are\n: Cuda 10.0, pytorch 1.0.0, python 3.6.8" + str(e))
+        
         torch.cuda.empty_cache()
 
         if self.classifier is not None:

--- a/TagLab.py
+++ b/TagLab.py
@@ -18,6 +18,7 @@
 #GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
 # for more details.
 
+import rasterio 
 import sys
 import os
 import datetime

--- a/install.py
+++ b/install.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 import os
+import re
 import subprocess
 from subprocess import STDOUT, check_call
 from pathlib import Path
@@ -10,7 +11,7 @@ if osused != 'Linux' and osused != 'Windows' and osused != 'Darwin':
     raise Exception("Operative System not supported")
 
 # check python version
-if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and (sys.version_info[1] != 11)):
+if sys.version_info < (3, 11):
     raise Exception("Python " + str(sys.version_info[0]) + "." + str(sys.version_info[1]) + " not supported. Please see https://github.com/cnr-isti-vclab/TagLab/wiki/Install-TagLab")
 
 # manage torch
@@ -22,18 +23,20 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and (sys.version_info[1]
 torch_install_dict = None
 
 win_torch_install_dict = {
-    '11.6': ['torch==1.13.1+cu116', 'torchvision==0.14.1+cu116', '--extra-index-url' + 'https://download.pytorch.org/whl/cu116'],
+    '11.6': ['torch==1.13.1+cu116', 'torchvision==0.14.1+cu116', '--extra-index-url', 'https://download.pytorch.org/whl/cu116'],
     '11.8': ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/cu118'],
     '12.1': ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/cu121'],
     '12.4': ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/cu124'],
+    '13.2': ['torch==2.12.1', 'torchvision==0.27.1', '--index-url', 'https://download.pytorch.org/whl/cu132'],
     'cpu' : ['torch==2.5', 'torchvision==0.20'],
 }
 
 lin_torch_install_dict = {
-    '11.6': ['torch==1.13.1+cu116', 'torchvision==0.14.1+cu116', '--extra-index-url' + 'https://download.pytorch.org/whl/cu116'],
+    '11.6': ['torch==1.13.1+cu116', 'torchvision==0.14.1+cu116', '--extra-index-url', 'https://download.pytorch.org/whl/cu116'],
     '11.8': ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/cu118'],
     '12.1': ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/cu121'],
     '12.4': ['torch==2.5', 'torchvision==0.20'],
+    '13.2': ['torch==2.12.1', 'torchvision==0.27.1', '--index-url', 'https://download.pytorch.org/whl/cu132'],
     'cpu' : ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/cpu'],
     'rocm': ['torch==2.5', 'torchvision==0.20', '--index-url', 'https://download.pytorch.org/whl/rocm6.2'],
 }
@@ -43,7 +46,7 @@ mac_torch_install_dict = {
 }
 
 # supported cuda versions by torch
-torch_cuda_versions = ['12.4', '12.1', '11.8', '11.6']
+torch_cuda_versions = ['13.2', '12.4', '12.1', '11.8', '11.6']
 
 if osused == 'Windows':
     torch_install_dict = win_torch_install_dict
@@ -83,10 +86,9 @@ if use_cpu == False:
     output = result[1]
     rc = result[0]
     if rc == 0:
-        pos = output.find('CUDA Version:')
-        if pos >= 0:
-            pos += 13
-            cuda_version = output[pos:pos+6]
+        cuda_match = re.search(r'CUDA(?:\s+UMD)?\s+Version:\s*(\d+\.\d+)', output)
+        if cuda_match is not None:
+            cuda_version = cuda_match.group(1)
             print('Found CUDA version: ' + cuda_version)
 
             # get the float number of the cuda version
@@ -254,6 +256,17 @@ if flag_install_SAM:
 # if on windows, first install the msvc runtime
 if osused == 'Windows':
     install_requires.insert(0, 'msvc-runtime')
+
+opencv_packages = [
+    'opencv-python',
+    'opencv-contrib-python',
+    'opencv-python-headless',
+    'opencv-contrib-python-headless',
+]
+subprocess.run(
+    [sys.executable, '-m', 'pip', 'uninstall', '-y', *opencv_packages],
+    check=False,
+)
 
 # installing all the packages
 for package in install_requires:

--- a/source/Tools.py
+++ b/source/Tools.py
@@ -5,31 +5,49 @@ from source.tools.EditPoints import EditPoints
 from source.tools.Scribbles import Scribbles
 from source.tools.CorrectivePoints import CorrectivePoints
 
-
-from source.tools.CreateCrack import CreateCrack
-from source.tools.SplitBlob import SplitBlob
-from source.tools.Assign import Assign
-from source.tools.EditBorder import EditBorder
-from source.tools.Watershed import Watershed
-from source.tools.BricksSegmentation import BricksSegmentation
-from source.tools.Rows import Rows
-from source.tools.Cut import Cut
-from source.tools.Freehand import Freehand
-from source.tools.Ruler import Ruler
-from source.tools.FourClicks import FourClicks
-from source.tools.Match import Match
-from source.tools.SelectPoints import SelectPoints
-from source.tools.SelectArea import SelectArea
-from source.tools.Ritm import Ritm
-from source.tools.PlaceAnnPoint import PlaceAnnPoint
-
 from PyQt5.QtCore import Qt, QObject, QPointF, QRectF, QFileInfo, QDir, pyqtSlot, pyqtSignal, QT_VERSION_STR
 
 import os
 import importlib
-if importlib.util.find_spec("segment_anything"):
-    from source.tools.Sam import Sam
-    from source.tools.SAMInteractive import SAMInteractive
+
+
+class _LazyTool:
+
+    def __init__(self, module_name, class_name, *args):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_class_name", class_name)
+        object.__setattr__(self, "_args", args)
+        object.__setattr__(self, "_instance", None)
+
+    def _load(self):
+        if self._instance is None:
+            module = importlib.import_module(self._module_name)
+            tool_class = getattr(module, self._class_name)
+            object.__setattr__(self, "_instance", tool_class(*self._args))
+        return self._instance
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def deactivate(self):
+        if self._instance is not None:
+            self._instance.deactivate()
+
+    def reset(self):
+        if self._instance is not None:
+            self._instance.reset()
+
+    def enable(self, enabled):
+        if enabled:
+            self._load().enable(True)
+        elif self._instance is not None:
+            self._instance.enable(False)
 
 # class Tools(object):
 class Tools(QObject):
@@ -67,26 +85,26 @@ class Tools(QObject):
     def createTools(self):
         # TOOLS - create all the tools
         self.tools = {
-            "CREATECRACK": CreateCrack(self.viewerplus),
-            "SPLITBLOB": SplitBlob(self.viewerplus, self.pick_points),
-            "ASSIGN": Assign(self.viewerplus),
-            "EDITBORDER": EditBorder(self.viewerplus, self.edit_points),
-            "CUT": Cut(self.viewerplus, self.edit_points),
-            "FREEHAND": Freehand(self.viewerplus, self.edit_points),
-            "WATERSHED": Watershed(self.viewerplus, self.scribbles),
+            "CREATECRACK": _LazyTool("source.tools.CreateCrack", "CreateCrack", self.viewerplus),
+            "SPLITBLOB": _LazyTool("source.tools.SplitBlob", "SplitBlob", self.viewerplus, self.pick_points),
+            "ASSIGN": _LazyTool("source.tools.Assign", "Assign", self.viewerplus),
+            "EDITBORDER": _LazyTool("source.tools.EditBorder", "EditBorder", self.viewerplus, self.edit_points),
+            "CUT": _LazyTool("source.tools.Cut", "Cut", self.viewerplus, self.edit_points),
+            "FREEHAND": _LazyTool("source.tools.Freehand", "Freehand", self.viewerplus, self.edit_points),
+            "WATERSHED": _LazyTool("source.tools.Watershed", "Watershed", self.viewerplus, self.scribbles),
             # "BRICKS": BricksSegmentation(self.viewerplus),
-            "RULER": Ruler(self.viewerplus, self.pick_points),
-            "FOURCLICKS": FourClicks(self.viewerplus, self.pick_points),
-            "PLACEANNPOINT": PlaceAnnPoint(self.viewerplus),
-            "MATCH": Match(self.viewerplus),
-            "SELECTPOINTS": SelectPoints(self.viewerplus, self.pick_points),
-            "SELECTAREA": SelectArea(self.viewerplus, self.pick_points),
-            "RITM": Ritm(self.viewerplus, self.corrective_points),
-            "ROWS": Rows(self.viewerplus),
+            "RULER": _LazyTool("source.tools.Ruler", "Ruler", self.viewerplus, self.pick_points),
+            "FOURCLICKS": _LazyTool("source.tools.FourClicks", "FourClicks", self.viewerplus, self.pick_points),
+            "PLACEANNPOINT": _LazyTool("source.tools.PlaceAnnPoint", "PlaceAnnPoint", self.viewerplus),
+            "MATCH": _LazyTool("source.tools.Match", "Match", self.viewerplus),
+            "SELECTPOINTS": _LazyTool("source.tools.SelectPoints", "SelectPoints", self.viewerplus, self.pick_points),
+            "SELECTAREA": _LazyTool("source.tools.SelectArea", "SelectArea", self.viewerplus, self.pick_points),
+            "RITM": _LazyTool("source.tools.Ritm", "Ritm", self.viewerplus, self.corrective_points),
+            "ROWS": _LazyTool("source.tools.Rows", "Rows", self.viewerplus),
         }
         if self.SAM_is_available:   #just if SAM is available
-            self.tools["SAM"] = Sam(self.viewerplus, self.pick_points)
-            self.tools["SAMINTERACTIVE"] = SAMInteractive(self.viewerplus, self.pick_points)
+            self.tools["SAM"] = _LazyTool("source.tools.Sam", "Sam", self.viewerplus, self.pick_points)
+            self.tools["SAMINTERACTIVE"] = _LazyTool("source.tools.SAMInteractive", "SAMInteractive", self.viewerplus, self.pick_points)
 
 
     def setTool(self, tool):


### PR DESCRIPTION
The pull request aims to fix two issues.

First issue was mentioned in [issues-216](https://github.com/cnr-isti-vclab/TagLab/issues/216), that the script would silently exit upon startup. It was pointed out in [pr-212](https://github.com/cnr-isti-vclab/TagLab/pull/212) that an early import of rasterio somehow fix the issue. After messing around with it a bit, it seemed like it's a conflict between rasterio and PyQt, If PyQt is imported before rasterio it crashes. A temporary fix is to import rasterio before PyQt in the main script. Ideally there should be another script that centralizes the import at the start, but I am not too eager to touch that now as it affects multiple scripts.

Second issue was slow startup, it just bothers me so much I have to do something about it. I think the main issue is too much import at the start of the script, so I changed some of them to be dynamically imported when needed.

This is tested with Python 3.11.9, PyQt/Qt 5.15.2, Rasterio 1.3.11, Rasterio GDAL 3.9.2, OSGeo GDAL 3.9.2, OpenCV-headless 5.0.0.93 on windows with CUDA 3.12. If there is any unwanted/addtional changes feel free to edit the branch.

Thank you.