### PR TITLE
fix: import rasterio before PyQt5 to prevent silent crash on startup

### DIFF
--- a/TagLab.py
+++ b/TagLab.py
@@ -29,6 +29,13 @@ import platform
 import pandas as pd
 import importlib
 
+# rasterio must be imported before PyQt5 to avoid silent crash on startup
+# see: https://github.com/cnr-isti-vclab/TagLab/issues/216
+try:
+    import rasterio
+except ImportError:
+    pass
+
 from PyQt5.QtCore import Qt, QSize, QMargins, QDir, QPoint, QPointF, QRectF, QTimer, pyqtSlot, pyqtSignal, QSettings, QFileInfo, QModelIndex
 from PyQt5.QtGui import QFontDatabase, QFont, QPixmap, QIcon, QKeySequence, QPen, QImageReader, QImage
 from PyQt5.QtWidgets import QApplication, QWidget, QMainWindow, QFileDialog, QComboBox, QMenuBar, QMenu, QSizePolicy, QScrollArea, \


### PR DESCRIPTION
## Problem

On some configurations, TagLab silently exits on startup with no error message.

## Root Cause

`rasterio` and `PyQt5` have a known import order conflict: if `PyQt5` is 
imported before `rasterio`, a silent crash occurs on startup.

In `TagLab.py`, `PyQt5` was imported at line 32, while `rasterio` was only 
imported later via `source/` modules (RasterOps.py, Image.py, Channel.py, etc.).

## Fix

Added an early `import rasterio` before the `PyQt5` imports, wrapped in 
`try/except ImportError` to handle environments where rasterio is not installed.

## References
- Issue #216
- PR #222 (same fix, different approach)

## Tested
- Python 3.12.1