### PR TITLE
Adjust install.py to only install packages if they aren't already installed

### DIFF
--- a/install.py
+++ b/install.py
@@ -256,8 +256,16 @@ if osused == 'Windows':
     install_requires.insert(0, 'msvc-runtime')
 
 # installing all the packages
+# installing all the packages
 for package in install_requires:
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+    try:
+        __import__(package)
+        print(f"'{package}' is already installed.")
+    except ImportError:
+        print(f"'{package}' not found. Installing via pip...")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+        __import__(package)
+        print(f"'{package}' successfully installed and imported.")
 
 # installing torch, gdal and rasterio
 

--- a/install.py
+++ b/install.py
@@ -256,7 +256,6 @@ if osused == 'Windows':
     install_requires.insert(0, 'msvc-runtime')
 
 # installing all the packages
-# installing all the packages
 for package in install_requires:
     try:
         __import__(package)


### PR DESCRIPTION
Minor adjustment to `install.py` to add a `try-except` when installing the required packages. This helps with more automated installation methods where the script running package installations could cause issues.

In my case, this is necessary to install on an HPC using EasyBuild